### PR TITLE
hotfix-SCRUM-51: fix collision and death handling

### DIFF
--- a/src/entity/GameModel.java
+++ b/src/entity/GameModel.java
@@ -318,8 +318,13 @@ public class GameModel {
 
 		List<Entity> entities = new ArrayList<>();
 
-		if (ship != null) entities.add(ship);
-		if (shipP2 != null) entities.add(shipP2);
+		if (ship != null && livesP1 > 0 && !ship.isDestroyed()) {
+			entities.add(ship);
+		}
+
+		if (shipP2 != null && livesP2 > 0 && !shipP2.isDestroyed()) {
+			entities.add(shipP2);
+		}
 
 		for (EnemyShip e : enemyShipFormationModel) {
 			if (e != null && !e.isDestroyed()) entities.add(e);


### PR DESCRIPTION
## 🚩 What is this PR?
Fixes an issue where player collision/death handling did not work correctly, causing dead ships to still collide and preventing proper game over.

## 📢 Changes-Detail
* Excluded destroyed or zero-life ships from collision detection
* Ensured game over triggers correctly when players die
* Fixed repeated collision/damage behavior after player death

## 📃 Progress
* Completed: Core collision/death handling fix
* To-do: None

## ✅ Checklist
- [x] Jira issue key is included (SCRUM-51)

## 📸 Screenshots or Video

## ⚙️ Additional Notes
Please check that dead ships no longer collide during boss phases.
